### PR TITLE
[EditorCommon] Added way for overriding BroadcastSelectionChange from…

### DIFF
--- a/Code/Sandbox/Plugins/EditorCommon/NodeGraph/NodeGraphView.h
+++ b/Code/Sandbox/Plugins/EditorCommon/NodeGraph/NodeGraphView.h
@@ -207,7 +207,7 @@ protected:
 	void AddCommentItem(CAbstractCommentItem& comment);
 	void AddConnectionItem(CAbstractConnectionItem& connection);
 
-	void BroadcastSelectionChange(bool forceClear = false);
+	virtual void BroadcastSelectionChange(bool forceClear = false);
 
 private:
 


### PR DESCRIPTION
… NodeGraphView class. It's need to be done if you use CInspector & QPropertyTree instead of legacy classes. Overriding this function used for create property tree in inspector by PopulateInspectorEvent